### PR TITLE
URServer: JC-1093 Specify local ip for tcp-connection

### DIFF
--- a/ur_robot_driver/include/ur_robot_driver/comm/reverse_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/reverse_interface.h
@@ -60,9 +60,10 @@ public:
   /*!
    * \brief Creates a ReverseInterface object including a URServer.
    *
+   * \param local_ip IP address the Server is started on
    * \param port Port the Server is started on
    */
-  ReverseInterface(uint32_t port) : server_(port)
+  ReverseInterface(std::string local_ip, uint32_t port) : server_(local_ip, port)
   {
     if (!server_.bind())
     {

--- a/ur_robot_driver/include/ur_robot_driver/comm/script_sender.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/script_sender.h
@@ -47,10 +47,11 @@ public:
   /*!
    * \brief Creates a ScriptSender object, including a new URServer and not yet started thread.
    *
+   * \param local_ip IP address the server is started on
    * \param port Port to start the server on
    * \param program Program to send to the robot upon request
    */
-  ScriptSender(uint32_t port, const std::string& program) : server_(port), script_thread_(), program_(program)
+  ScriptSender(std::string local_ip, uint32_t port, const std::string& program) : server_(local_ip, port), script_thread_(), program_(program)
   {
     if (!server_.bind())
     {

--- a/ur_robot_driver/include/ur_robot_driver/comm/server.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/server.h
@@ -41,6 +41,7 @@ namespace comm
 class URServer : private comm::TCPSocket
 {
 private:
+  std::string local_ip_;
   int port_;
   comm::TCPSocket client_;
 
@@ -51,9 +52,10 @@ public:
   /*!
    * \brief Creates a URServer object with a given port.
    *
+   * \param local_ip IP address the server is started on
    * \param port The port to open a socket on
    */
-  URServer(int port);
+  URServer(std::string local_ip, int port);
   /*!
    * \brief Closes the socket to allow for destruction of the object.
    */

--- a/ur_robot_driver/include/ur_robot_driver/ur/ur_driver.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/ur_driver.h
@@ -224,6 +224,7 @@ private:
   std::function<void(bool)> handle_program_state_;
 
   std::string robot_ip_;
+  std::string local_ip_;
   bool in_headless_mode_;
   std::string full_robot_program_;
 

--- a/ur_robot_driver/src/comm/server.cpp
+++ b/ur_robot_driver/src/comm/server.cpp
@@ -31,7 +31,7 @@ namespace ur_driver
 {
 namespace comm
 {
-URServer::URServer(int port) : port_(port)
+URServer::URServer(std::string local_ip, int port) : local_ip_(local_ip), port_(port)
 {
 }
 
@@ -66,8 +66,7 @@ bool URServer::open(int socket_fd, struct sockaddr* address, size_t address_len)
 
 bool URServer::bind()
 {
-  std::string empty;
-  bool res = TCPSocket::setup(empty, port_);
+  bool res = TCPSocket::setup(local_ip_, port_);
 
   if (!res)
     return false;

--- a/ur_robot_driver/src/ur/ur_driver.cpp
+++ b/ur_robot_driver/src/ur/ur_driver.cpp
@@ -84,7 +84,7 @@ ur_driver::UrDriver::UrDriver(const std::string& robot_ip, const std::string& sc
   rtde_frequency_ = rtde_client_->getMaxFrequency();
   servoj_time_ = 1.0 / rtde_frequency_;
 
-  std::string local_ip = rtde_client_->getIP();
+  local_ip_ = rtde_client_->getIP();
 
   std::string prog = readScriptFile(script_file);
   while (prog.find(JOINT_STATE_REPLACE) != std::string::npos)
@@ -101,7 +101,7 @@ ur_driver::UrDriver::UrDriver(const std::string& robot_ip, const std::string& sc
 
   while (prog.find(SERVER_IP_REPLACE) != std::string::npos)
   {
-    prog.replace(prog.find(SERVER_IP_REPLACE), SERVER_IP_REPLACE.length(), local_ip);
+    prog.replace(prog.find(SERVER_IP_REPLACE), SERVER_IP_REPLACE.length(), local_ip_);
   }
 
   while (prog.find(SERVER_PORT_REPLACE) != std::string::npos)
@@ -146,7 +146,7 @@ ur_driver::UrDriver::UrDriver(const std::string& robot_ip, const std::string& sc
   }
   else
   {
-    script_sender_.reset(new comm::ScriptSender(script_sender_port, prog));
+    script_sender_.reset(new comm::ScriptSender(local_ip_, script_sender_port, prog));
     script_sender_->start();
     LOG_DEBUG("Created script sender");
   }
@@ -204,7 +204,7 @@ bool UrDriver::stopControl()
 void UrDriver::startWatchdog()
 {
   handle_program_state_(false);
-  reverse_interface_.reset(new comm::ReverseInterface(reverse_port_));
+  reverse_interface_.reset(new comm::ReverseInterface(local_ip_, reverse_port_));
   reverse_interface_active_ = true;
   LOG_DEBUG("Created reverse interface");
 
@@ -230,7 +230,7 @@ void UrDriver::startWatchdog()
     // TODO: It would probably make sense to keep the same instance alive for the complete runtime
     // instead of killing it all the time.
     reverse_interface_->~ReverseInterface();
-    reverse_interface_.reset(new comm::ReverseInterface(reverse_port_));
+    reverse_interface_.reset(new comm::ReverseInterface(local_ip_, reverse_port_));
     reverse_interface_active_ = true;
   }
 }


### PR DESCRIPTION
The connection was previously established with an empty string, corresponding to ip 0.0.0.0. It seems like this sometimes can lead to connection issues if the system is run on a pc with more than one network card. Therefore we specify the local ip address to be the same as for the already established rtde-connection.